### PR TITLE
Prepare examples for RCP release 24.1

### DIFF
--- a/CvssAv/CvssAvAnalysis/CvssAvAnalysis.msd
+++ b/CvssAv/CvssAvAnalysis/CvssAvAnalysis.msd
@@ -27,7 +27,7 @@
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
     <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="18" />
-    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="90" />
+    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="91" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
     <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="4" />

--- a/CvssAv/CvssAvComposition/CvssAvComposition.msd
+++ b/CvssAv/CvssAvComposition/CvssAvComposition.msd
@@ -26,7 +26,7 @@
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
     <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="18" />
-    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="90" />
+    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="91" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
     <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="4" />

--- a/ISO21434/ISOComposition/ISOComposition.msd
+++ b/ISO21434/ISOComposition/ISOComposition.msd
@@ -23,7 +23,7 @@
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
     <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="18" />
-    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="90" />
+    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="91" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
     <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="4" />

--- a/ISO21434/ISOExample/ISOExample.msd
+++ b/ISO21434/ISOExample/ISOExample.msd
@@ -26,7 +26,7 @@
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
     <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="18" />
-    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="90" />
+    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="91" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
     <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="4" />

--- a/ISO21434/ISOExample/models/ISOExample.mps
+++ b/ISO21434/ISOExample/models/ISOExample.mps
@@ -455,6 +455,7 @@
   </registry>
   <node concept="1mQ_Fh" id="5wtRytMI6hp">
     <property role="TrG5h" value="Risk Treatment" />
+    <property role="3GE5qa" value="Security Concept" />
     <node concept="1mMvoj" id="5wtRytMI6hq" role="1mMvoh">
       <property role="1nI1IJ" value="1615192315275" />
       <node concept="1m7PKM" id="21hb9eTOxDa" role="1m7PKN">

--- a/RemoteUpdate1/ExampleAnalysis/ExampleAnalysis.msd
+++ b/RemoteUpdate1/ExampleAnalysis/ExampleAnalysis.msd
@@ -26,7 +26,7 @@
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
     <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="18" />
-    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="90" />
+    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="91" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
     <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="4" />

--- a/RemoteUpdate1/ExampleAnalysis/models/ExampleAnalysis.mps
+++ b/RemoteUpdate1/ExampleAnalysis/models/ExampleAnalysis.mps
@@ -1928,6 +1928,7 @@
   </node>
   <node concept="1mQ_Fh" id="5W_1Y9DMGvM">
     <property role="TrG5h" value="Risk Treatment" />
+    <property role="3GE5qa" value="Security Concept" />
     <node concept="1mMvoj" id="5W_1Y9DMGvN" role="1mMvoh">
       <property role="1nI1IJ" value="1649930346555" />
       <node concept="1m7PKM" id="5hdoB45MAXl" role="1m7PKN">

--- a/RemoteUpdate1/StandardComposition/StandardComposition.msd
+++ b/RemoteUpdate1/StandardComposition/StandardComposition.msd
@@ -23,7 +23,7 @@
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
     <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="18" />
-    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="90" />
+    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="91" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
     <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="4" />

--- a/RemoteUpdate2/ExampleAnalysis/ExampleAnalysis.msd
+++ b/RemoteUpdate2/ExampleAnalysis/ExampleAnalysis.msd
@@ -26,7 +26,7 @@
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
     <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="18" />
-    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="90" />
+    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="91" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
     <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="4" />

--- a/RemoteUpdate2/ExampleAnalysis/models/ExampleAnalysis.mps
+++ b/RemoteUpdate2/ExampleAnalysis/models/ExampleAnalysis.mps
@@ -1715,6 +1715,7 @@
   <node concept="1mQ_Fh" id="1E_VH$V8tTK">
     <property role="TrG5h" value="RiskTreatment" />
     <property role="1m7Ujk" value="2" />
+    <property role="3GE5qa" value="Security Concept" />
     <node concept="1mMvoj" id="1E_VH$V8tTL" role="1mMvoh">
       <property role="1nI1IJ" value="1541592302888" />
       <property role="1nI1ID" value="1541592424253" />

--- a/RemoteUpdate2/StandardComposition2/StandardComposition2.msd
+++ b/RemoteUpdate2/StandardComposition2/StandardComposition2.msd
@@ -26,7 +26,7 @@
     <language slang="l:7a060fae-09e0-4372-be36-6696d6554c0e:com.mbeddr.mpsutil.review.annotation" version="0" />
     <language slang="l:2bee351d-bcec-4897-88ae-1eb8b271032f:com.moraad.assessmentcatalog.descriptor" version="0" />
     <language slang="l:c1497963-7ffd-4da0-9a4d-74675c5ab7e2:com.moraad.components" version="18" />
-    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="90" />
+    <language slang="l:2bca1aa3-c113-4542-8ac2-2a6a30636981:com.moraad.core" version="91" />
     <language slang="l:d66daea8-e7a8-4305-aeaa-7ca535d07bd3:com.moraad.projectinfo" version="2" />
     <language slang="l:087be214-4868-4fa9-b3c2-52f1e47d6275:com.moraad.propagation" version="0" />
     <language slang="l:2283d35c-b541-4c39-bf04-8310ba3f92ff:com.moraad.reports" version="4" />


### PR DESCRIPTION
this introduces a few changes, some minor refactorings, some more impactful like integrating the Security Concept Phase into the examples
- terminology profiles are simplified
- virtual packages are unified
- existing assistants are moved under "Security Analysis.Assistants"
- the Risk Treatment chunk is moved to "Security Concept"
- existing Risk Treatments got assigned their Concept Phase "leads to" property
- new chunks for all but the CVSS example
- new assistants for all but the CVSS example
- new report items in the existing reports for the ISO Example

Note: The CVSS example focuses on the different style of calculation and doesn't model a whole system, therefore the Concept Phase isn't really applicable here.